### PR TITLE
Ledger reverse reading

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
@@ -675,14 +675,14 @@ public class LedgerHandle implements WriteHandle {
      */
     public void asyncReadEntries(long firstEntry, long lastEntry, ReadCallback cb, Object ctx) {
         // Little sanity check
-        if (firstEntry < 0 || firstEntry > lastEntry) {
+        if (Math.min(firstEntry, lastEntry) < 0) {
             LOG.error("IncorrectParameterException on ledgerId:{} firstEntry:{} lastEntry:{}",
                     ledgerId, firstEntry, lastEntry);
             cb.readComplete(BKException.Code.IncorrectParameterException, this, null, ctx);
             return;
         }
 
-        if (lastEntry > lastAddConfirmed) {
+        if (Math.max(firstEntry, lastEntry) > lastAddConfirmed) {
             LOG.error("ReadEntries exception on ledgerId:{} firstEntry:{} lastEntry:{} lastAddConfirmed:{}",
                     ledgerId, firstEntry, lastEntry, lastAddConfirmed);
             cb.readComplete(BKException.Code.ReadException, this, null, ctx);
@@ -721,7 +721,7 @@ public class LedgerHandle implements WriteHandle {
      */
     public void asyncReadUnconfirmedEntries(long firstEntry, long lastEntry, ReadCallback cb, Object ctx) {
         // Little sanity check
-        if (firstEntry < 0 || firstEntry > lastEntry) {
+        if (Math.min(firstEntry, lastEntry) < 0) {
             LOG.error("IncorrectParameterException on ledgerId:{} firstEntry:{} lastEntry:{}",
                     ledgerId, firstEntry, lastEntry);
             cb.readComplete(BKException.Code.IncorrectParameterException, this, null, ctx);
@@ -742,13 +742,13 @@ public class LedgerHandle implements WriteHandle {
     @Override
     public CompletableFuture<LedgerEntries> readAsync(long firstEntry, long lastEntry) {
         // Little sanity check
-        if (firstEntry < 0 || firstEntry > lastEntry) {
+        if (Math.min(firstEntry, lastEntry) < 0) {
             LOG.error("IncorrectParameterException on ledgerId:{} firstEntry:{} lastEntry:{}",
                     ledgerId, firstEntry, lastEntry);
             return FutureUtils.exception(new BKIncorrectParameterException());
         }
 
-        if (lastEntry > lastAddConfirmed) {
+        if (Math.max(firstEntry, lastEntry) > lastAddConfirmed) {
             LOG.error("ReadAsync exception on ledgerId:{} firstEntry:{} lastEntry:{} lastAddConfirmed:{}",
                     ledgerId, firstEntry, lastEntry, lastAddConfirmed);
             return FutureUtils.exception(new BKReadException());
@@ -783,7 +783,7 @@ public class LedgerHandle implements WriteHandle {
     @Override
     public CompletableFuture<LedgerEntries> readUnconfirmedAsync(long firstEntry, long lastEntry) {
         // Little sanity check
-        if (firstEntry < 0 || firstEntry > lastEntry) {
+        if (Math.min(firstEntry, lastEntry) < 0) {
             LOG.error("IncorrectParameterException on ledgerId:{} firstEntry:{} lastEntry:{}",
                     ledgerId, firstEntry, lastEntry);
             return FutureUtils.exception(new BKIncorrectParameterException());

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/MockReadHandle.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/MockReadHandle.java
@@ -69,9 +69,15 @@ class MockReadHandle implements ReadHandle {
                     log.debug("readEntries: first={} last={} total={}", firstEntry, lastEntry, entries.size());
                 }
                 List<LedgerEntry> seq = new ArrayList<>();
-                long entryId = firstEntry;
-                while (entryId <= lastEntry && entryId < entries.size()) {
-                    seq.add(entries.get((int) entryId++).duplicate());
+                long entryId = Math.min(firstEntry, lastEntry);
+                while (entryId <= Math.max(firstEntry, lastEntry) && entryId < entries.size()) {
+                    if (firstEntry > lastEntry) {
+                        entryId--;
+                    } else {
+                        entryId++;
+                    }
+                    seq.add(entries.get((int) entryId).duplicate());
+                    System.out.println(seq.toString());
                 }
                 if (log.isDebugEnabled()) {
                     log.debug("Entries read: {}", seq);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/api/BookKeeperApiTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/api/BookKeeperApiTest.java
@@ -56,7 +56,8 @@ import org.slf4j.event.LoggingEvent;
 public class BookKeeperApiTest extends MockBookKeeperTestCase {
 
     private static final byte[] bigData = new byte[1024];
-    private static final byte[] data = "foo".getBytes(UTF_8);
+    private static final byte[] dataFoo = "foo".getBytes(UTF_8);
+    private static final byte[] dataBar = "bar".getBytes(UTF_8);
     private static final byte[] password = "password".getBytes(UTF_8);
 
     @Rule
@@ -72,13 +73,13 @@ public class BookKeeperApiTest extends MockBookKeeperTestCase {
                 .execute())) {
 
             // test writer is able to write
-            writer.append(ByteBuffer.wrap(data));
+            writer.append(ByteBuffer.wrap(dataFoo));
             assertEquals(0L, writer.getLastAddPushed());
-            writer.append(Unpooled.wrappedBuffer(data));
+            writer.append(Unpooled.wrappedBuffer(dataFoo));
             assertEquals(1L, writer.getLastAddPushed());
-            long expectedEntryId = writer.append(ByteBuffer.wrap(data));
+            long expectedEntryId = writer.append(ByteBuffer.wrap(dataFoo));
             assertEquals(expectedEntryId, writer.getLastAddConfirmed());
-            assertEquals(3 * data.length, writer.getLength());
+            assertEquals(3 * dataFoo.length, writer.getLength());
         }
     }
 
@@ -97,11 +98,11 @@ public class BookKeeperApiTest extends MockBookKeeperTestCase {
 
             // test writer is able to write
             long entryId = 0;
-            writer.write(entryId++, ByteBuffer.wrap(data));
-            writer.write(entryId++, Unpooled.wrappedBuffer(data));
-            long expectedEntryId = writer.write(entryId++, ByteBuffer.wrap(data));
+            writer.write(entryId++, ByteBuffer.wrap(dataFoo));
+            writer.write(entryId++, Unpooled.wrappedBuffer(dataFoo));
+            long expectedEntryId = writer.write(entryId++, ByteBuffer.wrap(dataFoo));
             assertEquals(expectedEntryId, writer.getLastAddConfirmed());
-            assertEquals(3 * data.length, writer.getLength());
+            assertEquals(3 * dataFoo.length, writer.getLength());
         }
     }
 
@@ -120,11 +121,11 @@ public class BookKeeperApiTest extends MockBookKeeperTestCase {
 
             // test writer is able to write
             long entryId = 0;
-            writer.write(entryId++, ByteBuffer.wrap(data));
-            writer.write(entryId++, Unpooled.wrappedBuffer(data));
-            long expectedEntryId = writer.write(entryId++, ByteBuffer.wrap(data));
+            writer.write(entryId++, ByteBuffer.wrap(dataFoo));
+            writer.write(entryId++, Unpooled.wrappedBuffer(dataFoo));
+            long expectedEntryId = writer.write(entryId++, ByteBuffer.wrap(dataFoo));
             assertEquals(expectedEntryId, writer.getLastAddConfirmed());
-            assertEquals(3 * data.length, writer.getLength());
+            assertEquals(3 * dataFoo.length, writer.getLength());
         }
     }
 
@@ -140,9 +141,9 @@ public class BookKeeperApiTest extends MockBookKeeperTestCase {
                 .execute())) {
             assertEquals(1234, writer.getId());
             long entryId = 0;
-            writer.write(entryId++, ByteBuffer.wrap(data));
-            assertEquals(data.length, writer.getLength());
-            writer.write(entryId - 1, ByteBuffer.wrap(data));
+            writer.write(entryId++, ByteBuffer.wrap(dataFoo));
+            assertEquals(dataFoo.length, writer.getLength());
+            writer.write(entryId - 1, ByteBuffer.wrap(dataFoo));
         }
     }
 
@@ -249,9 +250,9 @@ public class BookKeeperApiTest extends MockBookKeeperTestCase {
                 .withPassword(password)
                 .execute())) {
             long lId = writer.getId();
-            // write data and populate LastAddConfirmed
-            writer.append(ByteBuffer.wrap(data));
-            writer.append(ByteBuffer.wrap(data));
+            // write dataFoo and populate LastAddConfirmed
+            writer.append(ByteBuffer.wrap(dataFoo));
+            writer.append(ByteBuffer.wrap(dataFoo));
 
             try (ReadHandle reader = result(newOpenLedgerOp()
                     .withPassword(password)
@@ -320,8 +321,8 @@ public class BookKeeperApiTest extends MockBookKeeperTestCase {
             .execute())) {
             lId = writer.getId();
 
-            writer.append(ByteBuffer.wrap(data));
-            writer.append(ByteBuffer.wrap(data));
+            writer.append(ByteBuffer.wrap(dataFoo));
+            writer.append(ByteBuffer.wrap(dataFoo));
             assertEquals(1L, writer.getLastAddPushed());
 
             // open with fencing
@@ -334,7 +335,7 @@ public class BookKeeperApiTest extends MockBookKeeperTestCase {
                 assertEquals(1L, reader.getLastAddConfirmed());
             }
 
-            writer.append(ByteBuffer.wrap(data));
+            writer.append(ByteBuffer.wrap(dataFoo));
 
         }
     }
@@ -382,10 +383,10 @@ public class BookKeeperApiTest extends MockBookKeeperTestCase {
                 .withPassword(password)
                 .execute().get()) {
             lId = writer.getId();
-            // write data and populate LastAddConfirmed
-            writer.append(ByteBuffer.wrap(data));
-            writer.append(ByteBuffer.wrap(data));
-            writer.append(ByteBuffer.wrap(data));
+            // write dataFoo and populate LastAddConfirmed
+            writer.append(ByteBuffer.wrap(dataFoo));
+            writer.append(ByteBuffer.wrap(dataFoo));
+            writer.append(ByteBuffer.wrap(dataFoo));
         }
 
         try (ReadHandle reader = newOpenLedgerOp()
@@ -400,12 +401,12 @@ public class BookKeeperApiTest extends MockBookKeeperTestCase {
                 AtomicLong i = new AtomicLong(0);
                 for (LedgerEntry e : entries) {
                     assertEquals(i.getAndIncrement(), e.getEntryId());
-                    assertArrayEquals(data, e.getEntryBytes());
+                    assertArrayEquals(dataFoo, e.getEntryBytes());
                 }
                 i.set(0);
                 entries.forEach((e) -> {
                         assertEquals(i.getAndIncrement(), e.getEntryId());
-                        assertArrayEquals(data, e.getEntryBytes());
+                        assertArrayEquals(dataFoo, e.getEntryBytes());
                     });
             }
         }


### PR DESCRIPTION
### Motivation

Due to a consumer requirement able to fetch N last messages before a MessageId (or a timestamp). I'm introducing ledger reverse reading using the existing ledger's API.

### Changes

I am adding a min/max comparison between the start and end positions of the ledger reader.